### PR TITLE
Enhance Flexibility of Styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://developers.braintreepayments.com/guides/drop-in/javascript/v3
 * paymentOptionPriority - [see in DOC](https://developers.braintreepayments.com/guides/drop-in/javascript/v3#payment-option-priority)
 * submitButtonText - Text of the submit button
 * className - CSS class for the outer container (defaults to `braintree-dropin-react`)
-* renderButton - Use a custom component for the submit button. Takes props `onClick`, `isDisabled` and `text`
+* renderSubmitButton - Use a custom component for the submit button. Takes props `onClick`, `isDisabled` and `text`
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ https://developers.braintreepayments.com/guides/drop-in/javascript/v3
 * paypalCredit - [see in DOC](https://developers.braintreepayments.com/guides/drop-in/javascript/v3#accepting-paypal-credit)
 * paymentOptionPriority - [see in DOC](https://developers.braintreepayments.com/guides/drop-in/javascript/v3#payment-option-priority)
 * submitButtonText - Text of the submit button
+* className - CSS class for the outer container (defaults to `braintree-dropin-react`)
+* renderButton - Use a custom component for the submit button. Takes props `onClick`, `isDisabled` and `text`
 
 ### Installation
 
@@ -46,4 +48,18 @@ div.braintree-dropin-react
   div.braintree-dropin-react-form
   div.braintree-dropin-react-submit-btn-wrapper
     button
+```
+
+#### Styled Components
+
+Compatible with [styled-components](https://github.com/styled-components/styled-components).
+
+```js
+const MyBraintreeDropin = styled(BraintreeDropin)`
+  padding: 20px;
+  .braintree-dropin-react-submit-btn-wrapper {
+    padding: 10px;
+    background-color: #eee;
+  }
+`;
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ class BraintreeDropIn extends React.Component {
       <div className={this.props.className}>
         <div className='braintree-dropin-react-form' />
         <div className='braintree-dropin-react-submit-btn-wrapper'>
-          {this.props.renderButton({
+          {this.props.renderSubmitButton({
             onClick: this.handleSubmit,
             isDisabled: this.state.isSubmitButtonDisabled,
             text: this.props.submitButtonText
@@ -152,10 +152,10 @@ BraintreeDropIn.propTypes = {
   paymentOptionPriority: PropTypes.array,
   submitButtonText: PropTypes.string,
   className: PropTypes.string,
-  renderButton: PropTypes.func
+  renderSubmitButton: PropTypes.func
 }
 
-const renderButton = ({onClick, isDisabled, text}) => {
+const renderSubmitButton = ({onClick, isDisabled, text}) => {
   return (
     <button
       onClick={onClick}
@@ -164,7 +164,7 @@ const renderButton = ({onClick, isDisabled, text}) => {
   )
 }
 
-renderButton.propTypes = {
+renderSubmitButton.propTypes = {
   onClick: PropTypes.func.isRequired,
   isDisabled: PropTypes.bool.isRequired,
   text: PropTypes.string.isRequired
@@ -173,7 +173,7 @@ renderButton.propTypes = {
 BraintreeDropIn.defaultProps = {
   className: 'braintree-dropin-react',
   submitButtonText: 'Purchase',
-  renderButton
+  renderSubmitButton
 }
 
 export default BraintreeDropIn

--- a/src/index.js
+++ b/src/index.js
@@ -124,13 +124,14 @@ class BraintreeDropIn extends React.Component {
 
   render = () => {
     return (
-      <div className='braintree-dropin-react'>
+      <div className={this.props.className}>
         <div className='braintree-dropin-react-form' />
         <div className='braintree-dropin-react-submit-btn-wrapper'>
-          <button
-            onClick={this.handleSubmit}
-            disabled={this.state.isSubmitButtonDisabled}
-          >{this.props.submitButtonText || 'Purchase'}</button>
+          {this.props.renderButton({
+            onClick: this.handleSubmit,
+            isDisabled: this.state.isSubmitButtonDisabled,
+            text: this.props.submitButtonText
+          })}
         </div>
       </div>
     )
@@ -149,7 +150,30 @@ BraintreeDropIn.propTypes = {
   paypal: PropTypes.object,
   paypalCredit: PropTypes.object,
   paymentOptionPriority: PropTypes.array,
-  submitButtonText: PropTypes.string
+  submitButtonText: PropTypes.string,
+  className: PropTypes.string,
+  renderButton: PropTypes.func
+}
+
+const renderButton = ({onClick, isDisabled, text}) => {
+  return (
+    <button
+      onClick={onClick}
+      disabled={isDisabled}
+    >{text}</button>
+  )
+}
+
+renderButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool.isRequired,
+  text: PropTypes.string.isRequired
+}
+
+BraintreeDropIn.defaultProps = {
+  className: 'braintree-dropin-react',
+  submitButtonText: 'Purchase',
+  renderButton
 }
 
 export default BraintreeDropIn


### PR DESCRIPTION
These changes will allow more options for customizing appearance. For example:

* When using a UI component library like `material-ui`, you can render a custom submit button (e.g., `RaisedButton`) instead of a plain html `button`.
* Adding a `className` prop provides support for `styled-components`.

These are non-breaking changes, which I have testing in my own app.