### PR TITLE
recreate drop-in on locale change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ class BraintreeDropIn extends React.Component {
     if (
       this.props.authorizationToken &&
       this.state.dropInInstance &&
-      prevProps.authorizationToken !== this.props.authorizationToken
+      (prevProps.authorizationToken !== this.props.authorizationToken || prevProps.locale !== this.props.locale)
     ) {
       this.tearDown().then(() => {
         this.setState({


### PR DESCRIPTION
Recreate the drop-in on props.locale change to allow switching locales on-demand.