### PR TITLE
Moved react/react-dom to peerDependencies instead of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintree-dropin-react",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "React Drop-in Payment UI Component",
   "main": "index.js",
   "scripts": {
@@ -55,7 +55,7 @@
     "webpack": "^2.5.1",
     "webpack-dev-server": "^2.4.5"
   },
-  "dependencies": {
+  "peerDependencies": {
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-dom": "^15.5.4"


### PR DESCRIPTION
Just a simple fix to the following error by moving the `dependencies` to `peerDependencies` as suggested [here](https://github.com/facebook/react/issues/10320#issuecomment-332353869)

![react-error](https://user-images.githubusercontent.com/1100155/34417142-1fdbe86a-ebb4-11e7-9faa-1e7d8efc6b66.png)
